### PR TITLE
Simplified Chinese Localization

### DIFF
--- a/src/main/resources/assets/worldtime/lang/zh_cn.json
+++ b/src/main/resources/assets/worldtime/lang/zh_cn.json
@@ -1,0 +1,27 @@
+{
+    "worldtime.config.gametime":        "显示游戏内时间",
+    "worldtime.config.gametimex":       "  -  X 轴百分比",
+    "worldtime.config.gametimey":       "  -  Y 轴百分比",
+    "worldtime.config.gametimeprefix":  "  -  调整文本样式",
+    
+    "worldtime.config.realtime":        "显示现实时间",
+    "worldtime.config.realtimex":       "  -  X 轴百分比",
+    "worldtime.config.realtimey":       "  -  Y 轴百分比",
+    "worldtime.config.realtimeprefix":  "  -  调整文本样式",
+    "worldtime.config.realtimeformat":  "  -  调整显示格式",
+
+    "worldtime.config.coords":          "显示坐标",
+    "worldtime.config.coordsx":         "  -  X 轴百分比",
+    "worldtime.config.coordsy":         "  -  Y 轴百分比",
+    "worldtime.config.coordsprefix":    "  -  调整文本样式",
+    "worldtime.config.coordsformat":    "  -  调整显示格式",
+    
+    "worldtime.config.tt.gametime":     "显示游戏内时间 §7( 20 分钟 / 天 )",
+    "worldtime.config.tt.realtime":     "显示现实时间",
+    "worldtime.config.tt.offsetleft":   "——  用于§l横向§r调节显示位置 §7( §r0§7 表示最左边 )",
+    "worldtime.config.tt.offsettop":    " |  用于§l纵向§r调节显示位置 §7( §r0§7 表示最上方 )",
+    "worldtime.config.tt.prefix":       "使用 “样式代码” 作为前缀来定制文本的样式\n§7( 例如: §r“&2”§7 会将文本变为§2翠绿色§7 )",
+    
+    "worldtime.config.tt.realtimeformat":   "决定了以何种格式显示现实时间\n§7( 详询 §6Java§7 中 §6SimpleDateFormat§7 类的示范 )",
+    "worldtime.config.tt.coordformat":      "决定了以何种格式显示你的坐标\n§7( 请使用 §2{X} {Y} {Z}§7 作为对应坐标的占位符 )"
+}


### PR DESCRIPTION
Also an issue and a suggestion. 

- Issue: Description of `"worldtime.config.coords"` is incorrect and missing in lang file. 
- Suggestion: Optimize config legibility by modifying strings such as `"Game Time X Percent"` and `"Game Time Prefix"` into `"  -  X Percent"` and `"  -  Prefix"`, making them arrange like lists. 